### PR TITLE
TarAlertLoader: extract gzipped (non tar) files in tar.gz archives

### DIFF
--- a/ampel/alert/load/TarAlertLoader.py
+++ b/ampel/alert/load/TarAlertLoader.py
@@ -4,8 +4,8 @@
 # License:             BSD-3-Clause
 # Author:              valery brinnel <firstname.lastname@gmail.com>
 # Date:                13.05.2018
-# Last Modified Date:  15.03.2021
-# Last Modified By:    valery brinnel <firstname.lastname@gmail.com>
+# Last Modified Date:  10.03.2022
+# Last Modified By:    Marcus Fenner <mf@physik.hu-berlin.de>
 
 import tarfile
 from typing import IO
@@ -22,7 +22,7 @@ class TarAlertLoader(AbsAlertLoader[IO[bytes]]):
 
 	tar_mode: str = 'r:gz'
 	start: int = 0
-	file_obj: None | IO[bytes]
+	file_obj: None | IO[bytes] | tarfile.ExFileObject
 	file_path: None | str
 	logger: AmpelLogger # actually optional
 

--- a/ampel/alert/load/TarAlertLoader.py
+++ b/ampel/alert/load/TarAlertLoader.py
@@ -8,6 +8,7 @@
 # Last Modified By:    Marcus Fenner <mf@physik.hu-berlin.de>
 
 import tarfile
+from gzip import GzipFile
 from typing import IO
 from ampel.log.AmpelLogger import AmpelLogger
 from ampel.abstract.AbsAlertLoader import AbsAlertLoader
@@ -102,7 +103,8 @@ class TarAlertLoader(AbsAlertLoader[IO[bytes]]):
 					return subfile_obj
 				else:
 					return next(self)
-
+			elif tar_info.name.endswith('.gz'):
+				return GzipFile(mode="rb", fileobj=file_obj)
 			return file_obj
 
 		return next(self)


### PR DESCRIPTION
extract gzipped alerts inside .tar.gz files
needed to load [LSST_ALERTS_BATCH.tar.gz](https://github.com/LSSTDESC/plasticc_alerts/blob/main/tests/test01/LSST_ALERTS_BATCH.tar.gz) from ELAsTiCC