### PR TITLE
AbsAlertLoader: inherit from AmpelUnit

### DIFF
--- a/ampel/abstract/AbsAlertLoader.py
+++ b/ampel/abstract/AbsAlertLoader.py
@@ -11,14 +11,14 @@ from collections.abc import Iterator
 from typing import Generic
 
 from ampel.base.AmpelABC import AmpelABC
-from ampel.base.AmpelBaseModel import AmpelBaseModel
+from ampel.base.AmpelUnit import AmpelUnit
 from ampel.base.decorator import abstractmethod
 from ampel.log.AmpelLogger import AmpelLogger
 from ampel.struct.Resource import Resource
 from ampel.types import T
 
 
-class AbsAlertLoader(AmpelABC, AmpelBaseModel, Generic[T], abstract=True):
+class AbsAlertLoader(AmpelUnit, AmpelABC, Generic[T], abstract=True):
 
 	@property
 	def logger(self) -> AmpelLogger:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ampel-alerts"
-version = "0.10.1"
+version = "0.10.2a0"
 description = "Alert support for the Ampel system"
 authors = ["Valery Brinnel"]
 maintainers = ["Jakob van Santen <jakob.van.santen@desy.de>"]


### PR DESCRIPTION
This allows AbsAlertLoader subclasses to use secrets and aliases