### PR TITLE
Use grouping context to acknowledge alerts

### DIFF
--- a/ampel/alert/AlertConsumer.py
+++ b/ampel/alert/AlertConsumer.py
@@ -338,56 +338,43 @@ class AlertConsumer(AbsEventUnit, AlertConsumerModel):
 					for counter in stats.filter_accepted:
 						counter.inc()
 
-				if filter_results:
+				with ingester.group([alert]):
 
-					stats.accepted.inc()
+					if filter_results:
 
-					try:
-						alert_extra: dict[str, Any] = {'alert': alert.id}
-						if self.include_alert_extra_with_keys and alert.extra:
-							for key, path in self.include_alert_extra_with_keys.items():
-								alert_extra[key] = get_by_path(alert.extra, path)
-						with stat_time.labels("ingest").time():
-							ing_hdlr.ingest(
-								alert.datapoints, filter_results, stock_id, alert.tag,
-								alert_extra, alert.extra.get('stock') if alert.extra else None
-							)
-					except (PyMongoError, AmpelLoggingError) as e:
-						print(f"{e.__class__.__name__}: abording run() procedure")
-						report_ingest_error(e, alert, filter_results)
-						raise e
+						stats.accepted.inc()
 
-					except Exception as e:
-						report_ingest_error(e, alert, filter_results)
-
-						if self.raise_exc:
+						try:
+							alert_extra: dict[str, Any] = {'alert': alert.id}
+							if self.include_alert_extra_with_keys and alert.extra:
+								for key, path in self.include_alert_extra_with_keys.items():
+									alert_extra[key] = get_by_path(alert.extra, path)
+							with stat_time.labels("ingest").time():
+								ing_hdlr.ingest(
+									alert.datapoints, filter_results, stock_id, alert.tag,
+									alert_extra, alert.extra.get('stock') if alert.extra else None
+								)
+						except Exception as e:
+							print(f"{e.__class__.__name__}: abording run() procedure")
+							report_ingest_error(e, alert, filter_results)
 							raise e
 
-						if self.error_max:
-							err += 1
+					else:
 
-						if err == self.error_max:
-							logger.error("Max number of error reached, breaking alert processing")
-							self.set_cancel_run(AlertConsumerError.TOO_MANY_ERRORS)
+						# All channels reject this alert
+						# no log entries goes into the main logs collection sinces those are redirected to Ampel_rej.
 
-				else:
-
-					# All channels reject this alert
-					# no log entries goes into the main logs collection sinces those are redirected to Ampel_rej.
-
-					# So we add a notification manually. For that, we don't use logger
-					# cause rejection messages were alreary logged into the console
-					# by the StreamHandler in channel specific RecordBufferingHandler instances.
-					# So we address directly db_logging_handler, and for that, we create
-					# a LogDocument manually.
-					lr = LightLogRecord(logger.name, LogFlag.INFO | logger.base_flag)
-					lr.stock = stock_id
-					lr.channel = reduced_chan_names # type: ignore[assignment]
-					lr.extra = {'a': alert.id, 'allout': True}
-					if db_logging_handler:
-						db_logging_handler.handle(lr)
-				
-				ingester.acknowledge_on_delivery(alert)
+						# So we add a notification manually. For that, we don't use logger
+						# cause rejection messages were alreary logged into the console
+						# by the StreamHandler in channel specific RecordBufferingHandler instances.
+						# So we address directly db_logging_handler, and for that, we create
+						# a LogDocument manually.
+						lr = LightLogRecord(logger.name, LogFlag.INFO | logger.base_flag)
+						lr.stock = stock_id
+						lr.channel = reduced_chan_names # type: ignore[assignment]
+						lr.extra = {'a': alert.id, 'allout': True}
+						if db_logging_handler:
+							db_logging_handler.handle(lr)
 
 				iter_count += 1
 				stats.alerts.inc()

--- a/poetry.lock
+++ b/poetry.lock
@@ -2,14 +2,14 @@
 
 [[package]]
 name = "ampel-core"
-version = "0.10.6a0"
+version = "0.10.6a2"
 description = "Alice in Modular Provenance-Enabled Land"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main"]
 files = [
-    {file = "ampel_core-0.10.6a0-py3-none-any.whl", hash = "sha256:4f985b321cd8487af6822d3b129c37af95fdc736c4545f2092718d4aaa653b5b"},
-    {file = "ampel_core-0.10.6a0.tar.gz", hash = "sha256:40b76853d5e357ef92ceb44a8affb7f85bdac627a75080ddafa4b483ebe23100"},
+    {file = "ampel_core-0.10.6a2-py3-none-any.whl", hash = "sha256:9a63f29257ab5159276e15bf5229eb192bac671608922d61af607b1bd42b6fa7"},
+    {file = "ampel_core-0.10.6a2.tar.gz", hash = "sha256:b023636bcf7dd5b09f69a99afd9ed0e224fc2dc5fca9d642277117af18d0e5ae"},
 ]
 
 [package.dependencies]
@@ -1045,4 +1045,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "482de6821dc5a6ccddbaaa498e122e2856957da5a453924a66bec86096bbd4c5"
+content-hash = "55a89b59e5f4d45dffde2fcb0e46760646309f14bbbfb0d2d6fb2832accf4d87"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ampel-alerts"
-version = "0.10.3a1"
+version = "0.10.3a2"
 description = "Alert support for the Ampel system"
 authors = ["Valery Brinnel"]
 maintainers = ["Jakob van Santen <jakob.van.santen@desy.de>"]
@@ -28,7 +28,7 @@ include = [
 
 [tool.poetry.dependencies]
 python = "^3.10"
-ampel-core = {version = ">=0.10.6a0,<0.11"}
+ampel-core = {version = ">=0.10.6a2,<0.11"}
 
 [tool.poetry.dev-dependencies]
 pytest = "^8.3.3"


### PR DESCRIPTION
#170 had the side-effect of separating upstream message acknowledgement from the messages actually being sent, resulting in consumers never committing their offsets. Roll this into the context manager to ensure they stay together.

Along the way, remove the special case for PyMongoError and AmpelLoggingError in ingestion error handling, treating all exceptions as fatal.